### PR TITLE
feat: Added feature to support uuid::Uuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ async-trait = "0.1"
 paste = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 serde = "1"
+uuid = { version = "1", optional = true, features = ["v4", "js", "serde"]}
 
 [features]
 chrono = ["dep:chrono", "dep:paste"]
+uuid = ["dep:uuid"]
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = "0.3"
-leptos-struct-table = { path = "../..", features = ["chrono"] }
+leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,3 +1,4 @@
+use crate::uuid::Uuid;
 use async_trait::async_trait;
 use chrono::NaiveDate;
 use leptos::*;
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[table(sortable)]
 pub struct Book {
     #[table(key)]
-    pub id: u32,
+    pub id: Uuid,
     pub title: String,
     pub author: String,
     pub publish_date: NaiveDate,
@@ -26,28 +27,28 @@ fn main() {
             cx,
             vec![
                 Book {
-                    id: 1,
+                    id: Uuid::default(),
                     title: "The Great Gatsby".to_string(),
                     author: "F. Scott Fitzgerald".to_string(),
                     publish_date: NaiveDate::from_ymd_opt(1925, 4, 10).unwrap(),
                     hidden_field: "hidden".to_string(),
                 },
                 Book {
-                    id: 2,
+                    id: Uuid::default(),
                     title: "The Grapes of Wrath".to_string(),
                     author: "John Steinbeck".to_string(),
                     publish_date: NaiveDate::from_ymd_opt(1939, 4, 14).unwrap(),
                     hidden_field: "not visible in the table".to_string(),
                 },
                 Book {
-                    id: 3,
+                    id: Uuid::default(),
                     title: "Nineteen Eighty-Four".to_string(),
                     author: "George Orwell".to_string(),
                     publish_date: NaiveDate::from_ymd_opt(1949, 6, 8).unwrap(),
                     hidden_field: "hidden".to_string(),
                 },
                 Book {
-                    id: 4,
+                    id: Uuid::default(),
                     title: "Ulysses".to_string(),
                     author: "James Joyce".to_string(),
                     publish_date: NaiveDate::from_ymd_opt(1922, 2, 2).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,8 @@ pub struct TemperatureMeasurement {
 mod class_providers;
 mod components;
 mod data_provider;
+#[cfg(feature = "uuid")]
+pub mod uuid;
 
 pub use class_providers::*;
 pub use components::*;

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,44 @@
+//! Support for [uuid::Uuid] type.
+
+use leptos::*;
+use serde::{Deserialize, Serialize};
+
+/// Newtype for [uuid::Uuid].
+#[derive(PartialEq, Copy, Clone, Debug, Serialize, Deserialize, Hash, Eq)]
+pub struct Uuid(uuid::Uuid);
+
+impl From<uuid::Uuid> for Uuid {
+    fn from(value: uuid::Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl std::str::FromStr for Uuid {
+    type Err = <uuid::Uuid as TryFrom<&'static str>>::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(uuid::Uuid::parse_str(s)?))
+    }
+}
+
+impl Default for Uuid {
+    fn default() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+}
+
+impl core::ops::Deref for Uuid {
+    type Target = uuid::Uuid;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl IntoView for Uuid {
+    fn into_view(self, cx: Scope) -> View {
+        view! {
+            cx,
+            <>{format!("{:?}", self.0)}</>
+        }
+        .into()
+    }
+}


### PR DESCRIPTION
This PR introduces a new feature `uuid` which enables to use the `uuid::Uuid` type within a table.

# Changes

- Added feature flag `uuid`
- Added module `uuid` that contains the actual implementation
- Replaced type of `id` with `uuid` in simple example

Looking forward to your ideas and adjustments.