### PR TITLE
Example enhancement to showcase #[deny(missing_docs)]

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,18 +1,26 @@
+#![deny(missing_docs)]
+//! Simple showcase example.
+
 use async_trait::async_trait;
 use chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use serde::{Deserialize, Serialize};
 
-// This generates the component BookTable
+/// This generates the component BookTable
 #[derive(TableComponent, Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 #[table(sortable)]
 pub struct Book {
+    /// Id of the entry.
     #[table(key)]
     pub id: u32,
+    /// Title of the book.
     pub title: String,
+    /// Author of the book.
     pub author: String,
+    /// Date when book has been published.
     pub publish_date: NaiveDate,
+    /// Example on hidden member.
     #[table(skip)]
     pub hidden_field: String,
 }


### PR DESCRIPTION
This PR is the addition to https://github.com/Synphonyte/leptos-struct-table-macro/pull/2 to show that this crate is also possible with `#[deny(missing_docs)]` enabled.

# Changes

- Added `#[deny(missing_docs)]` to the simple example
- Added documentations to the simple example