### PR TITLE
Enable leptos-use ssr feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Synphonyte/leptos-struct-table"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly"] }
 leptos-struct-table-macro = { version = "0.10.0" }
-leptos-use = "0.10"
+leptos-use = { version = "0.10", features = ["ssr"] }
 paste = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 serde = "1"


### PR DESCRIPTION
I was just getting `function not implemented on non-wasm32 targets` errors, but with this change it finally worked.
However, maybe this should be feature-gated in leptos-struct-table itself?