### PR TITLE
implement sqlx compatibility in uuid type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ paste = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 serde = "1"
 uuid = { version = "1", optional = true, features = ["v4", "js", "serde"] }
+sqlx = { version = "0.7", optional = true, features = ["uuid"] }
 thiserror = "1"
 web-sys = "0.3.67"
 wasm-bindgen = "0.2"
@@ -26,6 +27,9 @@ wasm-bindgen = "0.2"
 [features]
 chrono = ["dep:chrono", "dep:paste"]
 uuid = ["dep:uuid"]
+sqlx_postgres = ["dep:sqlx", "sqlx/postgres"]
+sqlx_mysql = ["dep:sqlx", "sqlx/mysql"]
+sqlx_sqlite = ["dep:sqlx", "sqlx/sqlite"]
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -42,3 +42,84 @@ impl IntoView for Uuid {
         .into()
     }
 }
+
+#[cfg(feature = "sqlx_postgres")]
+impl sqlx::Type<sqlx::Postgres> for Uuid {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <uuid::Uuid as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlx_postgres")]
+impl sqlx::postgres::PgHasArrayType for Uuid {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        <uuid::Uuid as sqlx::postgres::PgHasArrayType>::array_type_info()
+    }
+}
+
+#[cfg(feature = "sqlx_postgres")]
+impl sqlx::Encode<'_, sqlx::Postgres> for Uuid {
+    fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
+        <uuid::Uuid as sqlx::Encode<'_, sqlx::Postgres>>::encode_by_ref(&self.0, buf)
+    }
+}
+
+#[cfg(feature = "sqlx_postgres")]
+impl sqlx::Decode<'_, sqlx::Postgres> for Uuid {
+    fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        <uuid::Uuid as sqlx::Decode<'_, sqlx::Postgres>>::decode(value).map(|i| Uuid(i))
+    }
+}
+
+#[cfg(feature = "sqlx_mysql")]
+impl sqlx::Type<sqlx::MySql> for Uuid {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <uuid::Uuid as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::mysql::MySqlTypeInfo) -> bool {
+        <uuid::Uuid as sqlx::Type<sqlx::MySql>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx_mysql")]
+impl sqlx::Encode<'_, sqlx::MySql> for Uuid {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> sqlx::encode::IsNull {
+        <uuid::Uuid as sqlx::Encode<'_, sqlx::MySql>>::encode_by_ref(&self.0, buf)
+    }
+}
+
+#[cfg(feature = "sqlx_mysql")]
+impl sqlx::Decode<'_, sqlx::MySql> for Uuid {
+    fn decode(value: sqlx::mysql::MySqlValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        <uuid::Uuid as sqlx::Decode<'_, sqlx::MySql>>::decode(value).map(|i| Uuid(i))
+    }
+}
+
+#[cfg(feature = "sqlx_sqlite")]
+impl sqlx::Type<sqlx::Sqlite> for Uuid {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <uuid::Uuid as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::sqlite::SqliteTypeInfo) -> bool {
+        <uuid::Uuid as sqlx::Type<sqlx::Sqlite>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx_sqlite")]
+impl<'q> sqlx::Encode<'q, sqlx::Sqlite> for Uuid {
+    fn encode_by_ref(
+        &self,
+        args: &mut Vec<sqlx::sqlite::SqliteArgumentValue<'q>>,
+    ) -> sqlx::encode::IsNull {
+        <uuid::Uuid as sqlx::Encode<'_, sqlx::Sqlite>>::encode_by_ref(&self.0, args)
+    }
+}
+
+#[cfg(feature = "sqlx_sqlite")]
+impl sqlx::Decode<'_, sqlx::Sqlite> for Uuid {
+    fn decode(value: sqlx::sqlite::SqliteValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        <uuid::Uuid as sqlx::Decode<'_, sqlx::Sqlite>>::decode(value).map(|i| Uuid(i))
+    }
+}


### PR DESCRIPTION
This pull request is an attempt to make something like this work:
```rust 
#[derive(leptos_struct_table::TableRow, Clone, Serialize, Deserialize)]
#[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
#[table(sortable, classes_provider = ClassesPreset)]
pub struct User {
    pub id: leptos_struct_table::uuid::Uuid,
    pub name: String,
}
```

note that the Uuid here is the newtype from this library to support the leptos_struct_table::TableRow derive

This adds feature flags and implementations for the required sqlx stuff for the above to work on **postgres**
hopefully also mysql and sqlite (I have not tested these ones myself yet tho) _from what i can tell these are the database providers with an imementation for these in the sqlx library._

While the above seems to work i have no idea if this pr is a good idea (does feel like it could be a slippery slope to begin these kinds of extentions to the newtypes this library has to provide for convenient rendering) 
An alternative instead of placing this responsibility within this library would be to map from an sqlx struct (with `FromRow` implemented) to a leptos_struct_table struct (with appropriate newtypes instead of the `uuid::Uuid` type) feel free to close this pr if this is more of the direction you want this library to go. (if that is the case i would be happy to try to provide a pr with documentation (or extend the sqlx example with information on how to map a uuid type that works with `sqlx::FromRow` to a type that works with the `leptos_struct_table::TableRow` derive)
