### PR TITLE
Implement sorting on the sqlx example

### DIFF
--- a/examples/serverfn_sqlx/src/data_provider.rs
+++ b/examples/serverfn_sqlx/src/data_provider.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 
 #[derive(TableRow, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ssr", derive(sqlx::FromRow))]
-#[table(classes_provider = ClassesPreset)]
+#[table(sortable, classes_provider = ClassesPreset)]
 pub struct Customer {
     pub customer_id: String,
     pub first_name: String,
@@ -36,15 +36,15 @@ pub async fn list_customers(query: CustomerQuery) -> Result<Vec<Customer>, Serve
 
     let CustomerQuery { sort, range, name } = query;
 
-    let mut query = QueryBuilder::new("SELECT customer_id, first_name, last_name, company, city, country, phone, email, website FROM customers");
+    let mut query = QueryBuilder::new("SELECT customer_id, first_name, last_name, company, city, country, phone, email, website FROM customers ");
     if !name.is_empty() {
-        query.push(" WHERE first_name LIKE concat('%', ");
+        query.push("WHERE first_name LIKE concat('%', ");
         query.push_bind(&name);
         query.push(", '%') OR last_name LIKE concat('%', ");
         query.push_bind(&name);
         query.push(", '%') OR company LIKE concat('%', ");
         query.push_bind(&name);
-        query.push(", '%')");
+        query.push(", '%') ");
     }
 
     if let Some(order) = Customer::sorting_to_sql(&sort) {


### PR DESCRIPTION
This addresses the sorting not working on the sqlx example as shown on the live demo of the library at leptosconf.

With some small adjustements, namely that the table was not configured to support sorting by providing the `sortable` directive to the table. Both this and giving the sqlx query some whitespace before pusing the result of `sorting_to_sql` to the query. With these adjustements sorting works in the example as users might expect.

![picture](https://github.com/Synphonyte/leptos-struct-table/assets/7715996/e2ed58cb-6bd0-4630-b366-0cf698cf2404)
