### PR TITLE
Implement own value trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ leptos-use = "0.10"
 paste = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 serde = "1"
-uuid = { version = "1", optional = true, features = ["v4", "js", "serde"] }
+uuid = { version = "1", optional = true, features = [] }
 thiserror = "1"
 web-sys = "0.3.67"
 wasm-bindgen = "0.2"

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ As props of the [`TableContent`] component you can use the following:
 On the field level you can use the **`renderer`** attribute.
 
 It defaults to [`DefaultNumberTableCellRenderer`] for number types and [`DefaultTableCellRenderer`] for anything else.
-As long as Leptos supports rendering the type it will work.
+Works for any type that implements the [`CellValue`] trait that is implemented for types in the standard library, popular crates with feature flags and for your own type if you implement this trait for them.
 If the feature `chrono` is enabled then [`DefaultNaiveDateTableCellRenderer`], [`DefaultNaiveDateTimeTableCellRenderer`] and
 [`DefaultNaiveTimeTableCellRenderer`] are used for [`chrono::NaiveDate`], [`chrono::NaiveDateTime`] and [`chrono::NaiveTime`] respectively.
 

--- a/examples/custom_row_renderer/Cargo.toml
+++ b/examples/custom_row_renderer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.8", features= ["v4"]}
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/custom_row_renderer/src/main.rs
+++ b/examples/custom_row_renderer/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! Simple showcase example.
 
-use crate::uuid::Uuid;
+use ::uuid::Uuid;
 use chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
@@ -60,7 +60,7 @@ fn main() {
     mount_to_body(|| {
         let rows = vec![
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Great Gatsby".to_string(),
                 author: "F. Scott Fitzgerald".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1925, 4, 10).unwrap()),
@@ -71,7 +71,7 @@ fn main() {
                 rating: "5/5".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Grapes of Wrath".to_string(),
                 author: "John Steinbeck".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1939, 4, 14).unwrap()),
@@ -80,7 +80,7 @@ fn main() {
                 rating: "4/5".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Nineteen Eighty-Four".to_string(),
                 author: "George Orwell".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1949, 6, 8).unwrap()),
@@ -89,7 +89,7 @@ fn main() {
                 rating: "19/84".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Ulysses".to_string(),
                 author: "James Joyce".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1922, 2, 2).unwrap()),

--- a/examples/generic/Cargo.toml
+++ b/examples/generic/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
+uuid = { version= "1.8", features=["v4"]}
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/generic/src/main.rs
+++ b/examples/generic/src/main.rs
@@ -1,6 +1,6 @@
 //! Generic showcase example.
 
-use crate::uuid::Uuid;
+use ::uuid::Uuid;
 use chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
@@ -61,7 +61,7 @@ fn main() {
     mount_to_body(|| {
         let rows = vec![
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Great Gatsby".to_string(),
                 author: "F. Scott Fitzgerald".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1925, 4, 10).unwrap()),
@@ -71,7 +71,7 @@ fn main() {
                 custom_data: "custom data is a string here".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Grapes of Wrath".to_string(),
                 author: "John Steinbeck".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1939, 4, 14).unwrap()),
@@ -79,7 +79,7 @@ fn main() {
                 custom_data: "custom data is a string here".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Nineteen Eighty-Four".to_string(),
                 author: "George Orwell".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1949, 6, 8).unwrap()),
@@ -87,7 +87,7 @@ fn main() {
                 custom_data: "custom data is a string here".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Ulysses".to_string(),
                 author: "James Joyce".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1922, 2, 2).unwrap()),

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,6 +8,7 @@ leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1"
+uuid = { version="1.8", features=["v4", "serde"]}
 console_log = "1"
 log = "0.4"
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! Simple showcase example.
 
-use crate::uuid::Uuid;
+use ::uuid::Uuid;
 use chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
@@ -33,7 +33,7 @@ fn main() {
     mount_to_body(|| {
         let rows = vec![
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Great Gatsby".to_string(),
                 author: "F. Scott Fitzgerald".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1925, 4, 10).unwrap()),
@@ -43,7 +43,7 @@ fn main() {
                 hidden_field: "hidden".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "The Grapes of Wrath".to_string(),
                 author: "John Steinbeck".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1939, 4, 14).unwrap()),
@@ -51,7 +51,7 @@ fn main() {
                 hidden_field: "not visible in the table".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Nineteen Eighty-Four".to_string(),
                 author: "George Orwell".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1949, 6, 8).unwrap()),
@@ -59,7 +59,7 @@ fn main() {
                 hidden_field: "hidden".to_string(),
             },
             Book {
-                id: Uuid::default(),
+                id: Uuid::new_v4(),
                 title: "Ulysses".to_string(),
                 author: "James Joyce".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1922, 2, 2).unwrap()),

--- a/src/components/cell/mod.rs
+++ b/src/components/cell/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "chrono")]
 mod chrono;
+use crate::Value;
+
 #[cfg(feature = "chrono")]
 pub use self::chrono::*;
 
@@ -22,11 +24,11 @@ pub fn DefaultTableCellRenderer<T, F>(
     index: usize,
 ) -> impl IntoView
 where
-    T: IntoView + Clone + 'static,
+    T: Value + Clone + 'static,
     F: Fn(T) + 'static,
 {
     view! {
-        <td class=class>{value}</td>
+        <td class=class>{value.get().render_value()}</td>
     }
 }
 

--- a/src/components/cell/mod.rs
+++ b/src/components/cell/mod.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "chrono")]
 mod chrono;
-use crate::Value;
+use crate::CellValue;
 
 #[cfg(feature = "chrono")]
 pub use self::chrono::*;
@@ -24,7 +24,7 @@ pub fn DefaultTableCellRenderer<T, F>(
     index: usize,
 ) -> impl IntoView
 where
-    T: Value + Clone + 'static,
+    T: CellValue + Clone + 'static,
     F: Fn(T) + 'static,
 {
     view! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,12 +387,13 @@ pub use components::*;
 pub use data_provider::*;
 pub use display_strategy::*;
 pub use events::*;
+use leptos::{view, IntoView};
 pub use leptos_struct_table_macro::TableRow;
 pub use reload_controller::*;
 pub use scroll_container::*;
 pub use selection::*;
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 pub use table_row::*;
 
 /// Type of sorting of a column
@@ -431,3 +432,87 @@ impl ColumnSort {
     Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
 )]
 pub struct FieldGetter<T>(PhantomData<T>);
+
+// A value that is displayable in a table
+pub trait Value {
+    fn render_value(self) -> impl IntoView;
+}
+
+impl Value for String {
+    fn render_value(self) -> impl IntoView {
+        view! {
+            <>{self}</>
+        }
+    }
+}
+
+impl Value for &'static str {
+    fn render_value(self) -> impl IntoView {
+        view! {
+            <>{self}</>
+        }
+    }
+}
+impl Value for Cow<'static, str> {
+    fn render_value(self) -> impl IntoView {
+        view! {
+            <>{self}</>
+        }
+    }
+}
+
+macro_rules! viewable_primitive {
+  ($($child_type:ty),* $(,)?) => {
+    $(
+      impl Value for $child_type {
+        #[inline(always)]
+        fn render_value(self) -> impl IntoView {
+            view! {
+                <>{self.to_string()}</>
+            }
+        }
+      }
+    )*
+  };
+}
+
+viewable_primitive![
+    &String,
+    usize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    isize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    f32,
+    f64,
+    char,
+    bool,
+    std::net::IpAddr,
+    std::net::SocketAddr,
+    std::net::SocketAddrV4,
+    std::net::SocketAddrV6,
+    std::net::Ipv4Addr,
+    std::net::Ipv6Addr,
+    std::char::ToUppercase,
+    std::char::ToLowercase,
+    std::num::NonZeroI8,
+    std::num::NonZeroU8,
+    std::num::NonZeroI16,
+    std::num::NonZeroU16,
+    std::num::NonZeroI32,
+    std::num::NonZeroU32,
+    std::num::NonZeroI64,
+    std::num::NonZeroU64,
+    std::num::NonZeroI128,
+    std::num::NonZeroU128,
+    std::num::NonZeroIsize,
+    std::num::NonZeroUsize,
+    std::panic::Location<'_>,
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,12 +433,12 @@ impl ColumnSort {
 )]
 pub struct FieldGetter<T>(PhantomData<T>);
 
-// A value that is displayable in a table
-pub trait Value {
+// A value that can be rendered as part of a table 
+pub trait CellValue {
     fn render_value(self) -> impl IntoView;
 }
 
-impl Value for String {
+impl CellValue for String {
     fn render_value(self) -> impl IntoView {
         view! {
             <>{self}</>
@@ -446,14 +446,14 @@ impl Value for String {
     }
 }
 
-impl Value for &'static str {
+impl CellValue for &'static str {
     fn render_value(self) -> impl IntoView {
         view! {
             <>{self}</>
         }
     }
 }
-impl Value for Cow<'static, str> {
+impl CellValue for Cow<'static, str> {
     fn render_value(self) -> impl IntoView {
         view! {
             <>{self}</>
@@ -464,7 +464,7 @@ impl Value for Cow<'static, str> {
 macro_rules! viewable_primitive {
   ($($child_type:ty),* $(,)?) => {
     $(
-      impl Value for $child_type {
+      impl CellValue for $child_type {
         #[inline(always)]
         fn render_value(self) -> impl IntoView {
             view! {

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,44 +1,11 @@
 //! Support for [uuid::Uuid] type.
 
 use leptos::*;
-use serde::{Deserialize, Serialize};
 
-/// Newtype for [uuid::Uuid].
-#[derive(PartialEq, Copy, Clone, Debug, Serialize, Deserialize, Hash, Eq)]
-pub struct Uuid(uuid::Uuid);
-
-impl From<uuid::Uuid> for Uuid {
-    fn from(value: uuid::Uuid) -> Self {
-        Self(value)
-    }
-}
-
-impl std::str::FromStr for Uuid {
-    type Err = <uuid::Uuid as TryFrom<&'static str>>::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(uuid::Uuid::parse_str(s)?))
-    }
-}
-
-impl Default for Uuid {
-    fn default() -> Self {
-        Self(uuid::Uuid::new_v4())
-    }
-}
-
-impl core::ops::Deref for Uuid {
-    type Target = uuid::Uuid;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl IntoView for Uuid {
-    fn into_view(self) -> View {
+impl crate::Value for uuid::Uuid {
+    fn render_value(self) -> impl IntoView {
         view! {
-
-            <>{format!("{:?}", self.0)}</>
+            <>{self.to_string()}</>
         }
-        .into()
     }
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -2,7 +2,18 @@
 
 use leptos::*;
 
-impl crate::Value for uuid::Uuid {
+/// CellValue implementation for uuid for uuid to work with the TableRow derive
+/// ``` 
+/// # use leptos_struct_table::*;
+/// # use leptos::*;
+/// 
+/// #[derive(TableRow, Clone)]
+/// #[table]
+/// struct SomeStruct {
+///     my_field: ::uuid::Uuid
+/// }
+/// ```
+impl crate::CellValue for uuid::Uuid {
     fn render_value(self) -> impl IntoView {
         view! {
             <>{self.to_string()}</>


### PR DESCRIPTION
As per Rust rules it's not possible to implement a forigin trait on a forigin type, a common pattern to circumvent this is to introduce "newtypes" as we had previously on `Uuid`.
This however has some issues, namely that some standard crates has had important implementations provided for those types making usage of those libraries clunky together with `leptos-struct-table` this pr could make atleast some of those cases avoidable.

This pr:
* Introduces an owned trait `CellValue` (i'm open to sugestions on the name) that has imlementations similar to those of IntoView (for those that turn into text) (the macro is stolen right from the leptos codebase)
* Removes Uuid newtype and excessive dependance on `v4`, `v6`, `serde` and `js`,  feature flags of Uuid
* Implements `CellValue` for `uuid::Uuid` behind the uuid feature flag
* Updates examples to work with the above breaking changes (naming the dependency on uuid and using that type (and calling `new_v4()` instead of `default()`

and we can, in this crate provide some nice default rendering for the types of well known crates (behind feature flags) as done here with the `Uuid` type (the actual one from the `uuid` crate).  I think it would be nice to implement `CellValue` for some types from `time` along with other well known and well used crates in the ecosystem in upcomming pr-s

I have a feeling we could ditch a lot of the special handling built into the derive macro for `chrono` but not 100% sure about that yet.

I made a previous pr #26 that I agree is subpar. This aproach feels much better, atleast to me but I think it achives the same benefit in the end, that this library can be used together with `sqlx::FromRow` even in more complex cases

Any feedback welcome