### PR TITLE
[Fix] Update the examples to compile after the recent changes

### DIFF
--- a/examples/bootstrap/src/main.rs
+++ b/examples/bootstrap/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/custom_row_renderer/src/main.rs
+++ b/examples/custom_row_renderer/src/main.rs
@@ -2,7 +2,7 @@
 //! Simple showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/custom_type/src/main.rs
+++ b/examples/custom_type/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! Simple showcase example.
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use derive_more::{Deref, DerefMut};
 use leptos::*;
 use leptos_struct_table::*;

--- a/examples/editable/src/main.rs
+++ b/examples/editable/src/main.rs
@@ -2,7 +2,7 @@ mod renderer;
 mod tailwind;
 
 use crate::renderer::*;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use std::ops::Range;

--- a/examples/generic/src/main.rs
+++ b/examples/generic/src/main.rs
@@ -1,7 +1,7 @@
 //! Generic showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/getter/src/main.rs
+++ b/examples/getter/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/paginated_rest_datasource/src/models.rs
+++ b/examples/paginated_rest_datasource/src/models.rs
@@ -1,5 +1,5 @@
 use crate::renderer::ObjectLinkTableCellRenderer;
-use leptos::{IntoView};
+use leptos::IntoView;
 use leptos_struct_table::{FieldGetter, TableRow};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;

--- a/examples/paginated_rest_datasource/src/models.rs
+++ b/examples/paginated_rest_datasource/src/models.rs
@@ -1,5 +1,5 @@
 use crate::renderer::ObjectLinkTableCellRenderer;
-use leptos::{IntoView, View};
+use leptos::{IntoView};
 use leptos_struct_table::{FieldGetter, TableRow};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -17,7 +17,7 @@ pub enum Authors {
     Multiple(Vec<String>),
 }
 
-// we implement Display for Authors which gives use ToString as well. We'll use this for IntoView.
+// we implement Display for Authors which gives use ToString as well. We'll use this for CellValue.
 impl Display for Authors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -35,10 +35,12 @@ impl Default for Authors {
     }
 }
 
-// Anything that implements IntoView can be displayed by the default cell renderer.
-impl IntoView for Authors {
-    fn into_view(self) -> View {
-        self.to_string().into_view()
+// Anything that implements CellValue can be displayed by the default cell renderer.
+impl leptos_struct_table::CellValue for Authors {
+    type RenderOptions = ();
+    
+    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+        self.to_string()
     }
 }
 

--- a/examples/pagination/src/models.rs
+++ b/examples/pagination/src/models.rs
@@ -1,5 +1,5 @@
 use crate::tailwind::TailwindClassesPreset;
-use leptos::{IntoView, View};
+use leptos::IntoView;
 use leptos_struct_table::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -11,7 +11,7 @@ pub enum Authors {
     Multiple(Vec<String>),
 }
 
-// we implement Display for Authors which gives use ToString as well. We'll use this for IntoView.
+// we implement Display for Authors which gives use ToString as well. We'll use this for CellValue.
 impl Display for Authors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -29,10 +29,12 @@ impl Default for Authors {
     }
 }
 
-// Anything that implements IntoView can be displayed by the default cell renderer.
-impl IntoView for Authors {
-    fn into_view(self) -> View {
-        self.to_string().into_view()
+// Anything that implements CellValue can be displayed by the default cell renderer.
+impl leptos_struct_table::CellValue for Authors {
+    type RenderOptions = ();
+    
+    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+        self.to_string()
     }
 }
 

--- a/examples/selectable/src/main.rs
+++ b/examples/selectable/src/main.rs
@@ -1,6 +1,6 @@
 mod tailwind;
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use tailwind::TailwindClassesPreset;

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -2,7 +2,7 @@
 //! Simple showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/tailwind/src/main.rs
+++ b/examples/tailwind/src/main.rs
@@ -1,6 +1,6 @@
 mod tailwind;
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use tailwind::TailwindClassesPreset;


### PR DESCRIPTION
All the breaking changes introduced in the last couple of prs had made some of the examples break.

This changes the examples that relied on IntoView being the mecanism to display the cell value and also the now ambiguous chrono import when using a glob import on `leptos_struct_table` . Went through and got all examples to compile and made sure they still work.

I'm sorry for breaking them in the first place. (Maybe I could set up some pr that will run CI of the examples just like done on release)