### PR TITLE
 [Feature] Implement time support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ leptos-use = "0.10"
 rust_decimal = { version = "1.35", optional = true }
 chrono = { version = "0.4", optional = true }
 serde = "1"
-uuid = { version = "1", optional = true }
+time = { version= "0.3", optional= true, features=["formatting"]}
+uuid = { version = "1", optional = true, features = [] }
 thiserror = "1"
 web-sys = "0.3.67"
 wasm-bindgen = "0.2"
@@ -27,6 +28,7 @@ wasm-bindgen = "0.2"
 chrono = ["dep:chrono"]
 uuid = ["dep:uuid"]
 rust_decimal = ["dep:rust_decimal"]
+time = ["dep:time"]
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
-leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
+leptos-struct-table = { path = "../..", features = ["chrono", "uuid", "time"] }
 chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1"
+time= { version="0.3" }
 uuid = { version="1.8", features=["v4", "serde"]}
 console_log = "1"
 log = "0.4"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -3,6 +3,7 @@
 
 use ::uuid::Uuid;
 use ::chrono::NaiveDate;
+use ::time::Date;
 use leptos::*;
 use leptos_struct_table::*;
 
@@ -18,6 +19,8 @@ pub struct Book {
     pub author: String,
     /// Date when book has been published.
     pub publish_date: Option<NaiveDate>,
+    /// Date when book was read 
+    pub read_date: Option<Date>,
     /// Description of the book. Optional.
     #[table(none_value = "-")]
     pub description: Option<String>,
@@ -37,6 +40,7 @@ fn main() {
                 title: "The Great Gatsby".to_string(),
                 author: "F. Scott Fitzgerald".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1925, 4, 10).unwrap()),
+                read_date: Some(Date::from_calendar_date(2024, ::time::Month::January, 2).unwrap()),
                 description: Some(
                     "A story of wealth, love, and the American Dream in the 1920s.".to_string(),
                 ),
@@ -47,6 +51,7 @@ fn main() {
                 title: "The Grapes of Wrath".to_string(),
                 author: "John Steinbeck".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1939, 4, 14).unwrap()),
+                read_date: None,
                 description: None,
                 hidden_field: "not visible in the table".to_string(),
             },
@@ -55,6 +60,7 @@ fn main() {
                 title: "Nineteen Eighty-Four".to_string(),
                 author: "George Orwell".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1949, 6, 8).unwrap()),
+                read_date: None,
                 description: None,
                 hidden_field: "hidden".to_string(),
             },
@@ -63,6 +69,7 @@ fn main() {
                 title: "Ulysses".to_string(),
                 author: "James Joyce".to_string(),
                 publish_date: Some(NaiveDate::from_ymd_opt(1922, 2, 2).unwrap()),
+                read_date: None,
                 description: None,
                 hidden_field: "hidden".to_string(),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,8 @@ mod uuid;
 pub mod rust_decimal;
 #[cfg(feature = "chrono")]
 pub mod chrono;
+#[cfg(feature = "time")]
+pub mod time;
 pub use class_providers::*;
 pub use components::*;
 pub use data_provider::*;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,108 @@
+#![doc(cfg(feature = "time"))]
+
+//! Support for [::time] crate.
+use ::time::{Date, PrimitiveDateTime, OffsetDateTime, Time};
+use ::time::format_description;
+use leptos::*;
+use crate::*;
+
+#[derive(Default)]
+pub struct RenderTimeOptions {
+    /// Specifies a format string see [the time book](https://time-rs.github.io/book/api/format-description.html).
+    pub string: Option<String>,
+}
+
+/// Implementation for [`Date`] to work with the [`TableRow`] derive and the [`DefaultTableCellRenderer`]
+/// ``` 
+/// # use leptos_struct_table::*;
+/// # use leptos::*;
+/// # use ::time::Date;
+/// #[derive(TableRow, Clone)]
+/// #[table]
+/// struct SomeStruct {
+///     #[table(format(string = "[year]-[month]-[day]"))]
+///     my_field: Date
+/// }
+/// ```
+impl CellValue for Date {
+    type RenderOptions = RenderTimeOptions;
+    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+        if let Some(value) = options.string.as_ref() {
+            let format = format_description::parse(value).unwrap();
+            self.format(&format).unwrap()
+        } else {
+            self.to_string()
+        }
+    }
+}
+/// Implementation for [`Time`] to work with the [`TableRow`] derive and the [`DefaultTableCellRenderer`]
+/// ``` 
+/// # use leptos_struct_table::*;
+/// # use leptos::*;
+/// # use ::time::Time;
+/// #[derive(TableRow, Clone)]
+/// #[table]
+/// struct SomeStruct {
+///     #[table(format(string = "[hour]:[minute]:[second]"))]
+///     my_field: Time
+/// }
+/// ```
+impl CellValue for Time {
+    type RenderOptions = RenderTimeOptions;
+    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+        if let Some(value) = options.string.as_ref() {
+            let format = format_description::parse(value).unwrap();
+            self.format(&format).unwrap()
+        } else {
+            self.to_string()
+        }
+    }
+}
+
+/// Implementation for [`PrimitiveDateTime`] to work with the [`TableRow`] derive and the [`DefaultTableCellRenderer`]
+/// ``` 
+/// # use leptos_struct_table::*;
+/// # use leptos::*;
+/// # use ::time::PrimitiveDateTime;
+/// #[derive(TableRow, Clone)]
+/// #[table]
+/// struct SomeStruct {
+///     #[table(format(string = "[year]-[month]-[day] [hour]:[minute]:[second]"))]
+///     my_field: PrimitiveDateTime
+/// }
+/// ```
+impl CellValue for PrimitiveDateTime {
+    type RenderOptions = RenderTimeOptions;
+    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+        if let Some(value) = options.string.as_ref() {
+            let format = format_description::parse(value).unwrap();
+            self.format(&format).unwrap()
+        } else {
+            self.to_string()
+        }
+    }
+}
+
+/// Implementation for [`OffsetDateTime`] to work with the [`TableRow`] derive and the [`DefaultTableCellRenderer`]
+/// ``` 
+/// # use leptos_struct_table::*;
+/// # use leptos::*;
+/// # use ::time::OffsetDateTime;
+/// #[derive(TableRow, Clone)]
+/// #[table]
+/// struct SomeStruct {
+///     #[table(format(string = "[year]-[month]-[day] [hour]:[minute]:[second] Z[offset_hour]"))]
+///     my_field: OffsetDateTime
+/// }
+/// ```
+impl CellValue for OffsetDateTime {
+    type RenderOptions = RenderTimeOptions;
+    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+        if let Some(value) = options.string.as_ref() {
+            let format = format_description::parse(value).unwrap();
+            self.format(&format).unwrap()
+        } else {
+            self.to_string()
+        }
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -28,8 +28,8 @@ impl CellValue for Date {
     type RenderOptions = RenderTimeOptions;
     fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
-            let format = format_description::parse(value).unwrap();
-            self.format(&format).unwrap()
+            let format = format_description::parse(value).expect("Unable to construct a format description given the format string");
+            self.format(&format).expect("Unable to format given the format description")
         } else {
             self.to_string()
         }
@@ -51,8 +51,8 @@ impl CellValue for Time {
     type RenderOptions = RenderTimeOptions;
     fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
-            let format = format_description::parse(value).unwrap();
-            self.format(&format).unwrap()
+            let format = format_description::parse(value).expect("Unable to construct a format description given the format string");
+            self.format(&format).expect("Unable to format given the format description")
         } else {
             self.to_string()
         }
@@ -75,8 +75,8 @@ impl CellValue for PrimitiveDateTime {
     type RenderOptions = RenderTimeOptions;
     fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
-            let format = format_description::parse(value).unwrap();
-            self.format(&format).unwrap()
+            let format = format_description::parse(value).expect("Unable to construct a format description given the format string");
+            self.format(&format).expect("Unable to format given the format description")
         } else {
             self.to_string()
         }
@@ -99,8 +99,8 @@ impl CellValue for OffsetDateTime {
     type RenderOptions = RenderTimeOptions;
     fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
-            let format = format_description::parse(value).unwrap();
-            self.format(&format).unwrap()
+            let format = format_description::parse(value).expect("Unable to construct a format description given the format string");
+            self.format(&format).expect("Unable to format given the format description")
         } else {
             self.to_string()
         }


### PR DESCRIPTION
With the previous changes introduced in prs #28 and #29 its now trivial to support the time library with custom CellValue implementations behind a feature flag.

this `CellValue` implementation accepts a format string just like chrono, but this string is the `time` libraries own format specifier. [reference](https://time-rs.github.io/book/api/format-description.html)