### PR TITLE
[Fix] Remove unneccery feature flag on chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ leptos = { version = "0.6", features = ["nightly"] }
 leptos-struct-table-macro = { version = "0.10.0", path="../leptos-struct-table-macro" }
 leptos-use = "0.10"
 rust_decimal = { version = "1.35", optional = true }
-chrono = { version = "0.4", optional = true, features = ["serde"] }
+chrono = { version = "0.4", optional = true }
 serde = "1"
-uuid = { version = "1", optional = true, features = [] }
+uuid = { version = "1", optional = true }
 thiserror = "1"
 web-sys = "0.3.67"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
We had an unneccery dependency on the `serde` feature flag of chrono. 

Unneccerely increasing compile time when the user does not need any serde features.