### PR TITLE
[Fix] Reduce dependencies on the examples 

### DIFF
--- a/examples/bootstrap/Cargo.toml
+++ b/examples/bootstrap/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features=["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/bootstrap/src/main.rs
+++ b/examples/bootstrap/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/custom_renderers_svg/Cargo.toml
+++ b/examples/custom_renderers_svg/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
-leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features=["serde"] }
+leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/custom_row_renderer/Cargo.toml
+++ b/examples/custom_row_renderer/Cargo.toml
@@ -11,7 +11,6 @@ uuid = { version = "1.8", features= ["v4"]}
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"
-serde = "1"
 
 [dev-dependencies]
 wasm-bindgen = "0.2"

--- a/examples/custom_row_renderer/Cargo.toml
+++ b/examples/custom_row_renderer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 uuid = { version = "1.8", features= ["v4"]}
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/custom_row_renderer/src/main.rs
+++ b/examples/custom_row_renderer/src/main.rs
@@ -2,7 +2,7 @@
 //! Simple showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/custom_type/Cargo.toml
+++ b/examples/custom_type/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/custom_type/src/main.rs
+++ b/examples/custom_type/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! Simple showcase example.
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use derive_more::{Deref, DerefMut};
 use leptos::*;
 use leptos_struct_table::*;

--- a/examples/editable/Cargo.toml
+++ b/examples/editable/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features=["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/editable/src/main.rs
+++ b/examples/editable/src/main.rs
@@ -2,7 +2,7 @@ mod renderer;
 mod tailwind;
 
 use crate::renderer::*;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use std::ops::Range;

--- a/examples/generic/Cargo.toml
+++ b/examples/generic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 uuid = { version= "1.8", features=["v4"]}
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/generic/src/main.rs
+++ b/examples/generic/src/main.rs
@@ -1,7 +1,7 @@
 //! Generic showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/getter/Cargo.toml
+++ b/examples/getter/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/getter/src/main.rs
+++ b/examples/getter/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/paginated_rest_datasource/Cargo.toml
+++ b/examples/paginated_rest_datasource/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-use = "0.10"
-leptos-struct-table = { path = "../..", features = ["chrono"] }
+leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/paginated_rest_datasource/src/models.rs
+++ b/examples/paginated_rest_datasource/src/models.rs
@@ -1,5 +1,5 @@
 use crate::renderer::ObjectLinkTableCellRenderer;
-use leptos::{IntoView};
+use leptos::IntoView;
 use leptos_struct_table::{FieldGetter, TableRow};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;

--- a/examples/paginated_rest_datasource/src/models.rs
+++ b/examples/paginated_rest_datasource/src/models.rs
@@ -1,5 +1,5 @@
 use crate::renderer::ObjectLinkTableCellRenderer;
-use leptos::{IntoView, View};
+use leptos::{IntoView};
 use leptos_struct_table::{FieldGetter, TableRow};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -17,7 +17,7 @@ pub enum Authors {
     Multiple(Vec<String>),
 }
 
-// we implement Display for Authors which gives use ToString as well. We'll use this for IntoView.
+// we implement Display for Authors which gives use ToString as well. We'll use this for CellValue.
 impl Display for Authors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -35,10 +35,12 @@ impl Default for Authors {
     }
 }
 
-// Anything that implements IntoView can be displayed by the default cell renderer.
-impl IntoView for Authors {
-    fn into_view(self) -> View {
-        self.to_string().into_view()
+// Anything that implements CellValue can be displayed by the default cell renderer.
+impl leptos_struct_table::CellValue for Authors {
+    type RenderOptions = ();
+    
+    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+        self.to_string()
     }
 }
 

--- a/examples/pagination/Cargo.toml
+++ b/examples/pagination/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
-leptos-struct-table = { path = "../..", features = ["chrono"] }
+leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/pagination/src/models.rs
+++ b/examples/pagination/src/models.rs
@@ -1,5 +1,5 @@
 use crate::tailwind::TailwindClassesPreset;
-use leptos::{IntoView, View};
+use leptos::IntoView;
 use leptos_struct_table::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -11,7 +11,7 @@ pub enum Authors {
     Multiple(Vec<String>),
 }
 
-// we implement Display for Authors which gives use ToString as well. We'll use this for IntoView.
+// we implement Display for Authors which gives use ToString as well. We'll use this for CellValue.
 impl Display for Authors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -29,10 +29,12 @@ impl Default for Authors {
     }
 }
 
-// Anything that implements IntoView can be displayed by the default cell renderer.
-impl IntoView for Authors {
-    fn into_view(self) -> View {
-        self.to_string().into_view()
+// Anything that implements CellValue can be displayed by the default cell renderer.
+impl leptos_struct_table::CellValue for Authors {
+    type RenderOptions = ();
+    
+    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+        self.to_string()
     }
 }
 

--- a/examples/selectable/Cargo.toml
+++ b/examples/selectable/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features=["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/selectable/src/main.rs
+++ b/examples/selectable/src/main.rs
@@ -1,6 +1,6 @@
 mod tailwind;
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use tailwind::TailwindClassesPreset;

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
-uuid = { version="1.8", features=["v4", "serde"]}
+uuid = { version="1.8", features=["v4"]}
 console_log = "1"
 log = "0.4"
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -2,7 +2,7 @@
 //! Simple showcase example.
 
 use ::uuid::Uuid;
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.6", features = ["nightly", "csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
-chrono = { version = "0.4", features=["serde"] }
+chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -10,7 +10,6 @@ chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"
-serde = "1"
 
 [dev-dependencies]
 wasm-bindgen = "0.2"

--- a/examples/tailwind/src/main.rs
+++ b/examples/tailwind/src/main.rs
@@ -1,6 +1,6 @@
 mod tailwind;
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::*;
 use leptos_struct_table::*;
 use tailwind::TailwindClassesPreset;


### PR DESCRIPTION
This pr expands on pr #31, it removes some unnecessary dependencies in the examples, 

- Removes dependency on `serde` where its not needed 
- Removes feature flag toggles of `chrono` and `uuid` that included serde support.

