### PR TITLE
Remove use of nightly rust to support stable rust

### DIFF
--- a/.github/actions/rust_toolchain/action.yml
+++ b/.github/actions/rust_toolchain/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         profile: minimal
         override: true
         components: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/Synphonyte/leptos-struct-table"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly"] }
+leptos = { version = "0.6" }
 leptos-struct-table-macro = { version = "0.10.0", path="../leptos-struct-table-macro" }
 leptos-use = "0.10"
 rust_decimal = { version = "1.35", optional = true }

--- a/examples/bootstrap/Cargo.toml
+++ b/examples/bootstrap/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -1,11 +1,10 @@
 A simple table example with just local data stored as `Vec<Book>` Uses the Bootstrap class provider.
 
 If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/bootstrap/rust-toolchain.toml
+++ b/examples/bootstrap/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/custom_renderers_svg/Cargo.toml
+++ b/examples/custom_renderers_svg/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/custom_renderers_svg/README.md
+++ b/examples/custom_renderers_svg/README.md
@@ -1,11 +1,10 @@
 Example that shows how use custom renderers to render the table as SVG.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/custom_renderers_svg/rust-toolchain.toml
+++ b/examples/custom_renderers_svg/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/custom_renderers_svg/src/renderers.rs
+++ b/examples/custom_renderers_svg/src/renderers.rs
@@ -118,13 +118,13 @@ where
     F: Fn(TableHeadEvent) + 'static,
 {
     let style = move || {
-        let sort = match sort_direction() {
+        let sort = match sort_direction.get() {
             ColumnSort::Ascending => "--sort-icon: '▲';",
             ColumnSort::Descending => "--sort-icon: '▼';",
             ColumnSort::None => "--sort-icon: '';",
         };
 
-        let priority = match sort_priority() {
+        let priority = match sort_priority.get() {
             Some(priority) => format!("--sort-priority: '{}';", priority + 1),
             None => "--sort-priority: '';".to_string(),
         };

--- a/examples/custom_row_renderer/Cargo.toml
+++ b/examples/custom_row_renderer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4" }
 uuid = { version = "1.8", features= ["v4"]}

--- a/examples/custom_row_renderer/README.md
+++ b/examples/custom_row_renderer/README.md
@@ -1,11 +1,10 @@
 A simple table example with just local data stored as `Vec<Book>` demonstrating a custom row renderer and skipping header titles.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/custom_row_renderer/rust-toolchain.toml
+++ b/examples/custom_row_renderer/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/custom_type/Cargo.toml
+++ b/examples/custom_type/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/custom_type/README.md
+++ b/examples/custom_type/README.md
@@ -1,11 +1,10 @@
 A table example with custom local data stored as `Vec<Rc<Book>>`.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/custom_type/rust-toolchain.toml
+++ b/examples/custom_type/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/editable/Cargo.toml
+++ b/examples/editable/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/editable/README.md
+++ b/examples/editable/README.md
@@ -5,12 +5,11 @@ The way Tailwind works, is to scan the classes in the code. Due to this it is
 recommended to copy the file `src/class_providers/tailwind.rs` into your project as done in this example.
 
 If you don't have it installed already, install [Trunk](https://trunkrs.dev/) and [Tailwind](https://tailwindcss.com/docs/installation)
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
 npm install -D tailwindcss
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/editable/rust-toolchain.toml
+++ b/examples/editable/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/editable/src/main.rs
+++ b/examples/editable/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
                 </table>
             </div>
 
-            <pre>{move || format!("{:#?}", rows())}</pre>
+            <pre>{move || format!("{:#?}", rows.get())}</pre>
         }
     })
 }

--- a/examples/generic/Cargo.toml
+++ b/examples/generic/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid"] }
 chrono = { version = "0.4" }
 uuid = { version= "1.8", features=["v4"]}

--- a/examples/generic/README.md
+++ b/examples/generic/README.md
@@ -1,11 +1,10 @@
 A table example with a generic struct.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/generic/rust-toolchain.toml
+++ b/examples/generic/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/getter/Cargo.toml
+++ b/examples/getter/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/getter/README.md
+++ b/examples/getter/README.md
@@ -1,11 +1,10 @@
 A table example with a getter method.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/getter/rust-toolchain.toml
+++ b/examples/getter/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/paginated_rest_datasource/Cargo.toml
+++ b/examples/paginated_rest_datasource/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-use = "0.10"
 leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"

--- a/examples/paginated_rest_datasource/README.md
+++ b/examples/paginated_rest_datasource/README.md
@@ -1,11 +1,10 @@
 Example that shows how to use a paginated REST API as a data source for a table.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/paginated_rest_datasource/rust-toolchain.toml
+++ b/examples/paginated_rest_datasource/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/paginated_rest_datasource/src/main.rs
+++ b/examples/paginated_rest_datasource/src/main.rs
@@ -40,7 +40,7 @@ pub fn App() -> impl IntoView {
                         value=rows.search
                     />
                 </div>
-                <Show when=move || { count() > 0 }>
+                <Show when=move || { count.get() > 0 }>
                     <div>"Found " {count} " results"</div>
                 </Show>
             </div>
@@ -51,7 +51,7 @@ pub fn App() -> impl IntoView {
                         scroll_container=container
                         loading_cell_inner_class="loading-skeleton"
                         reload_controller=reload_controller
-                        on_row_count=set_count
+                        on_row_count=move |count| set_count.set(count)
                     />
                 </table>
             </div>

--- a/examples/pagination/Cargo.toml
+++ b/examples/pagination/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-struct-table = { path = "../.." }
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -1,12 +1,11 @@
 Example that shows how to use pagination with a table.
 
 If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
 npm install -D tailwindcss
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/pagination/rust-toolchain.toml
+++ b/examples/pagination/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/pagination/src/main.rs
+++ b/examples/pagination/src/main.rs
@@ -36,11 +36,11 @@ pub fn Paginator(pagination_controller: PaginationController) -> impl IntoView {
     let page_count = pagination_controller.page_count();
 
     let page_range = move || {
-        let mut start = current_page().saturating_sub(2);
+        let mut start = current_page.get().saturating_sub(2);
 
         let mut end = start + 5;
 
-        if let Some(row_count) = page_count() {
+        if let Some(row_count) = page_count.get() {
             if end > row_count {
                 end = row_count;
                 start = end.saturating_sub(5);

--- a/examples/selectable/Cargo.toml
+++ b/examples/selectable/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/selectable/README.md
+++ b/examples/selectable/README.md
@@ -4,12 +4,11 @@ The way Tailwind works, is to scan the classes in the code. Due to this it is
 recommended to copy the file `src/class_providers/tailwind.rs` into your project as done in this example.
 
 If you don't have it installed already, install [Trunk](https://trunkrs.dev/) and [Tailwind](https://tailwindcss.com/docs/installation)
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
 npm install -D tailwindcss
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/selectable/rust-toolchain.toml
+++ b/examples/selectable/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/serverfn_sqlx/Cargo.toml
+++ b/examples/serverfn_sqlx/Cargo.toml
@@ -10,12 +10,12 @@ crate-type = ["cdylib", "rlib"]
 axum = { version = "0.7", optional = true }
 console_error_panic_hook = "0.1"
 http = "1"
-leptos = { version = "0.6", features = ["nightly"] }
+leptos = { version = "0.6" }
 leptos-struct-table = { path = "../.." }
 leptos-use = "0.10"
 leptos_axum = { version = "0.6", optional = true }
-leptos_meta = { version = "0.6", features = ["nightly"] }
-leptos_router = { version = "0.6", features = ["nightly"] }
+leptos_meta = { version = "0.6" }
+leptos_router = { version = "0.6" }
 serde = { version = "1.0.197", features = ["derive"] }
 sqlx = { version = "0.7", optional = true, features = ["sqlite", "runtime-tokio-rustls"] }
 thiserror = "1"

--- a/examples/serverfn_sqlx/rust-toolchain.toml
+++ b/examples/serverfn_sqlx/rust-toolchain.toml
@@ -1,3 +1,0 @@
-
-[toolchain]
-channel = "nightly"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 leptos-struct-table = { path = "../..", features = ["chrono", "uuid", "time"] }
 chrono = { version = "0.4", features = [] }
 console_error_panic_hook = "0.1"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,11 +1,10 @@
 A simple table example with just local data stored as `Vec<Book>`.
 
-If you don't have it installed already, install [Trunk](https://trunkrs.dev/) 
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+If you don't have it installed already, install [Trunk](https://trunkrs.dev/)
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/simple/rust-toolchain.toml
+++ b/examples/simple/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.6", features = ["nightly", "csr"]}
+leptos = { version = "0.6", features = ["csr"]}
 leptos-struct-table = { path = "../..", features = ["chrono"] }
 chrono = { version = "0.4" }
 console_error_panic_hook = "0.1"

--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -4,12 +4,11 @@ The way Tailwind works, is to scan the classes in the code. Due to this it is
 recommended to copy the file `src/class_providers/tailwind.rs` into your project as done in this example.
 
 If you don't have it installed already, install [Trunk](https://trunkrs.dev/) and [Tailwind](https://tailwindcss.com/docs/installation)
-as well as the nightly toolchain for Rust and the wasm32-unknown-unknown target:
+as well as the wasm32-unknown-unknown target:
 
 ```bash
 cargo install trunk
 npm install -D tailwindcss
-rustup toolchain install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/examples/tailwind/rust-toolchain.toml
+++ b/examples/tailwind/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,4 +1,3 @@
-#![doc(cfg(feature = "chrono"))]
 
 //! Support for [::chrono] crate.
 use ::chrono::{NaiveDate, NaiveDateTime, NaiveTime};

--- a/src/components/table_content.rs
+++ b/src/components/table_content.rs
@@ -253,7 +253,7 @@ where
         move |event: TableHeadEvent| {
             sorting.update(move |sorting| update_sorting_from_event(sorting, event));
 
-            rows.borrow_mut().set_sorting(&sorting());
+            rows.borrow_mut().set_sorting(&sorting.get());
 
             clear(false);
         }
@@ -666,7 +666,7 @@ fn compute_average_row_height_from_loaded<Row, ClsP>(
             if let Some(avg_row_height) = avg_row_height {
                 let prev_placeholder_height_before = placeholder_height_before.get_untracked();
 
-                set_average_row_height(avg_row_height);
+                set_average_row_height.set(avg_row_height);
 
                 let new_placeholder_height_before = placeholder_height_before.get_untracked();
                 set_y(

--- a/src/components/thead.rs
+++ b/src/components/thead.rs
@@ -44,13 +44,13 @@ where
     F: Fn(TableHeadEvent) + 'static,
 {
     let style = move || {
-        let sort = match sort_direction() {
+        let sort = match sort_direction.get() {
             ColumnSort::Ascending => "--sort-icon: '▲';",
             ColumnSort::Descending => "--sort-icon: '▼';",
             ColumnSort::None => "--sort-icon: '';",
         };
 
-        let priority = match sort_priority() {
+        let priority = match sort_priority.get() {
             Some(priority) => format!("--sort-priority: '{}';", priority + 1),
             None => "--sort-priority: '';".to_string(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,6 @@ pub struct TemperatureMeasurement {
 //! All contributions are welcome. Please open an issue or a pull request if you have any ideas or problems.
 
 #![allow(non_snake_case)]
-#![feature(doc_cfg)]
 
 mod class_providers;
 mod components;

--- a/src/rust_decimal.rs
+++ b/src/rust_decimal.rs
@@ -1,4 +1,3 @@
-#![doc(cfg(feature = "rust_decimal"))]
 
 //! Support for [::rust_decimal] crate.
 use crate::*;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,3 @@
-#![doc(cfg(feature = "time"))]
 
 //! Support for [::time] crate.
 use ::time::{Date, PrimitiveDateTime, OffsetDateTime, Time};

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,5 +1,4 @@
 //! Support for [uuid::Uuid] type.
-#![doc(cfg(feature = "uuid"))]
 use leptos::*;
 use ::uuid::Uuid;
 use crate::*;


### PR DESCRIPTION
Fixes https://github.com/Synphonyte/leptos-struct-table/issues/35

Removes the use of the Rust nightly toolchain from the library and the all the examples. Also removes all the plcaes where the project requests the nightly toolchain: all the `rust-toolchain.toml`s and in the CI.

`cargo check` passes for the working directory and for each example.

Side note: cargo does not autodetect the examples, which is annoying because it means they all need a separate `cargo check` invocation.