### PR TITLE
Bump leptos-use version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Synphonyte/leptos-struct-table"
 [dependencies]
 leptos = { version = "0.6" }
 leptos-struct-table-macro = { version = "0.11.1" }
-leptos-use = "0.11"
+leptos-use = "0.12"
 rust_decimal = { version = "1.35", optional = true }
 chrono = { version = "0.4", optional = true }
 serde = "1"


### PR DESCRIPTION
Hi, I was trying to use this crate but ran into this issue when compiling:

error[E0599]: no variant or associated item named `__Nonexhaustive` found for enum `web_sys::NotificationPermission` in the current scope
   --> /home/francis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos-use-0.11.4/src/use_web_notification.rs:484:46
    |
484 |             web_sys::NotificationPermission::__Nonexhaustive => Self::Default,
    |                                              ^^^^^^^^^^^^^^^ variant or associated item not found in `NotificationPermission`
    
 Updating the `leptos-use` dependency to `0.12.0` fixes it.