### PR TITLE
Fixes tests and macros for leptos-0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Synphonyte/leptos-struct-table"
 
 [dependencies]
 leptos = { version = "0.7.0" }
-leptos-struct-table-macro = { version = "0.12", git = "https://github.com/kstep/leptos-struct-table-macro", branch = "leptos-0.7" }
+leptos-struct-table-macro = { version = "0.12" }
 leptos-use = "0.15.0"
 rust_decimal = { version = "1.35", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-struct-table"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Marc-Stefan Cassola"]
 categories = ["gui", "web-programming", "wasm"]
@@ -13,7 +13,7 @@ repository = "https://github.com/Synphonyte/leptos-struct-table"
 
 [dependencies]
 leptos = { version = "0.7.0" }
-leptos-struct-table-macro = { version = "0.11.2" }
+leptos-struct-table-macro = { version = "0.12", git = "https://github.com/kstep/leptos-struct-table-macro", branch = "leptos-0.7" }
 leptos-use = "0.15.0"
 rust_decimal = { version = "1.35", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/examples/paginated_rest_datasource/src/models.rs
+++ b/examples/paginated_rest_datasource/src/models.rs
@@ -39,7 +39,7 @@ impl Default for Authors {
 impl leptos_struct_table::CellValue for Authors {
     type RenderOptions = ();
     
-    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, _options: Self::RenderOptions) -> impl IntoView {
         self.to_string()
     }
 }

--- a/examples/pagination/src/models.rs
+++ b/examples/pagination/src/models.rs
@@ -33,7 +33,7 @@ impl Default for Authors {
 impl leptos_struct_table::CellValue for Authors {
     type RenderOptions = ();
     
-    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, _options: Self::RenderOptions) -> impl IntoView {
         self.to_string()
     }
 }

--- a/examples/selectable/src/main.rs
+++ b/examples/selectable/src/main.rs
@@ -1,6 +1,6 @@
 mod tailwind;
 
-use chrono::NaiveDate;
+use ::chrono::NaiveDate;
 use leptos::prelude::*;
 use leptos_struct_table::*;
 use tailwind::TailwindClassesPreset;

--- a/src/cell_value.rs
+++ b/src/cell_value.rs
@@ -1,8 +1,5 @@
 use leptos::prelude::*;
 
-#[doc(hidden)]
-pub type DefaultMarker = ();
-
 #[derive(Default, Clone, Copy)]
 pub struct NumberRenderOptions {
     /// Specifies the number of digits to display after the decimal point
@@ -19,7 +16,7 @@ pub trait CellValue<M: ?Sized> {
     fn render_value(self, options: Self::RenderOptions) -> impl IntoView;
 }
 
-impl<V> CellValue<DefaultMarker> for V
+impl<V> CellValue<()> for V
 where
     V: IntoView,
 {

--- a/src/cell_value.rs
+++ b/src/cell_value.rs
@@ -1,5 +1,8 @@
 use leptos::prelude::*;
 
+#[doc(hidden)]
+pub type DefaultMarker = ();
+
 #[derive(Default, Clone, Copy)]
 pub struct NumberRenderOptions {
     /// Specifies the number of digits to display after the decimal point
@@ -16,7 +19,7 @@ pub trait CellValue<M: ?Sized> {
     fn render_value(self, options: Self::RenderOptions) -> impl IntoView;
 }
 
-impl<V> CellValue<()> for V
+impl<V> CellValue<DefaultMarker> for V
 where
     V: IntoView,
 {

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -4,7 +4,7 @@ use crate::*;
 use ::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use leptos::prelude::*;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct RenderChronoOptions {
     /// Specifies a format string, See [`::chrono::format::strftime`] for more information.
     pub string: Option<String>,
@@ -19,7 +19,7 @@ macro_rules! chrono_cell_value_impl {
         impl CellValue<$ty> for $ty {
             type RenderOptions = RenderChronoOptions;
 
-            fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+            fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
                 if let Some(value) = options.string.as_ref() {
                     self.format(&value).to_string()
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ pub struct TemperatureMeasurement {
 //! #[component]
 //! fn ImageTableCellRenderer<F>(
 //!     class: String,
-//!     #[prop(into)] value: MaybeSignal<String>,
+//!     #[prop(into)] value: Signal<String>,
 //!     on_change: F,
 //!     index: usize,
 //! ) -> impl IntoView
@@ -315,7 +315,7 @@ pub struct TemperatureMeasurement {
 //! uses an `<input>`.
 //!
 //! ```
-//! # use leptos::prelude::*;
+//! # use leptos::{prelude::*, logging};
 //! # use leptos_struct_table::*;
 //! #
 //! #[derive(TableRow, Clone, Default, Debug)]
@@ -330,7 +330,7 @@ pub struct TemperatureMeasurement {
 //! #[component]
 //! fn InputCellRenderer<F>(
 //!     class: String,
-//!     #[prop(into)] value: MaybeSignal<String>,
+//!     #[prop(into)] value: Signal<String>,
 //!     on_change: F,
 //!     index: usize,
 //! ) -> impl IntoView

--- a/src/rust_decimal.rs
+++ b/src/rust_decimal.rs
@@ -22,7 +22,7 @@ pub struct DecimalNumberRenderOptions {
 /// ```
 impl CellValue<Decimal> for Decimal {
     type RenderOptions = DecimalNumberRenderOptions;
-    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.precision.as_ref() {
             format!("{:.value$}", self)
         } else {

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,7 @@ use ::time::format_description;
 use ::time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 use leptos::prelude::*;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct RenderTimeOptions {
     /// Specifies a format string see [the time book](https://time-rs.github.io/book/api/format-description.html).
     pub string: Option<String>,
@@ -26,7 +26,7 @@ pub struct RenderTimeOptions {
 impl CellValue<Date> for Date {
     type RenderOptions = RenderTimeOptions;
 
-    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
             let format = format_description::parse(value)
                 .expect("Unable to construct a format description given the format string");
@@ -52,7 +52,7 @@ impl CellValue<Date> for Date {
 impl CellValue<Time> for Time {
     type RenderOptions = RenderTimeOptions;
 
-    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
             let format = format_description::parse(value)
                 .expect("Unable to construct a format description given the format string");
@@ -79,7 +79,7 @@ impl CellValue<Time> for Time {
 impl CellValue<PrimitiveDateTime> for PrimitiveDateTime {
     type RenderOptions = RenderTimeOptions;
 
-    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
             let format = format_description::parse(value)
                 .expect("Unable to construct a format description given the format string");
@@ -106,7 +106,7 @@ impl CellValue<PrimitiveDateTime> for PrimitiveDateTime {
 impl CellValue<OffsetDateTime> for OffsetDateTime {
     type RenderOptions = RenderTimeOptions;
 
-    fn render_value(self, options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, options: Self::RenderOptions) -> impl IntoView {
         if let Some(value) = options.string.as_ref() {
             let format = format_description::parse(value)
                 .expect("Unable to construct a format description given the format string");

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -17,7 +17,7 @@ use leptos::prelude::*;
 impl CellValue<Uuid> for Uuid {
     type RenderOptions = ();
 
-    fn render_value(self, _options: &Self::RenderOptions) -> impl IntoView {
+    fn render_value(self, _options: Self::RenderOptions) -> impl IntoView {
         self.to_string()
     }
 }


### PR DESCRIPTION
Tests were failing, also `#[derive(TableRow)]` generated invalid code. This PR fixes it. See also https://github.com/Synphonyte/leptos-struct-table-macro/pull/10