### PR TITLE
Readme compat update

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ fn Demo() -> impl IntoView {
 }
 ```
 
+## Leptos Compatibility
+
+| Crate version | Compatible Leptos version |
+|---------------|---------------------------|
+| <= 0.2        | 0.3                       |
+| 0.3           | 0.4                       |
+| 0.4, 0.5, 0.6 | 0.5                       |
+| 0.7 – 0.12    | 0.6                       |
+| 0.14.0-beta2  | 0.7                       |
+
 ## Server-Side Rendering
 
 To use this with Leptos' server-side rendering, you can have to add `leptos-use` as a dependency to your `Cargo.toml` and

--- a/README.md
+++ b/README.md
@@ -366,14 +366,4 @@ and at the sections [Struct attributes](#struct-attributes) and
 
 All contributions are welcome. Please open an issue or a pull request if you have any ideas or problems.
 
-<!-- cargo-rdme end -->
-
-## Leptos Compatibility
-
-| Crate version | Compatible Leptos version |
-|---------------|---------------------------|
-| <= 0.2        | 0.3                       |
-| 0.3           | 0.4                       |
-| 0.4, 0.5, 0.6 | 0.5                       |
-| 0.7 – 0.13    | 0.6                       |
-| 0.14          | 0.7                       |
+<!-- cargo-rdme end -->                 |


### PR DESCRIPTION
I moved the compatibility table below the usage section. I think it's important for the usage section to be visible on first glance. The compatibility section is another important thing, but less than the usage example.
Added a reference to the beta version for leptos 0.7.