### PR TITLE
Adapt to allow `--cfg erase_components` usage

### DIFF
--- a/src/components/table_content.rs
+++ b/src/components/table_content.rs
@@ -188,10 +188,10 @@ pub fn TableContent<Row, DataP, Err, ClsP, ScrollEl, ScrollM>(
 where
     Row: TableRow<ClassesProvider = ClsP> + Clone + Send + Sync + 'static,
     DataP: TableDataProvider<Row, Err> + 'static,
-    Err: Debug,
+    Err: Debug + 'static,
     ClsP: TableClassesProvider + Send + Sync + Copy + 'static,
-    ScrollEl: IntoElementMaybeSignal<web_sys::Element, ScrollM>,
-    ScrollM: ?Sized,
+    ScrollEl: IntoElementMaybeSignal<web_sys::Element, ScrollM> + 'static,
+    ScrollM: ?Sized + 'static,
 {
     let on_change = StoredValue::new(on_change);
     let rows = Rc::new(RefCell::new(rows));


### PR DESCRIPTION
This PR allows leptos-struct-table to be used with the `--cfg erase_components` compiler cfg introduced here: https://github.com/leptos-rs/leptos/pull/2905

For my specific app this helps quite significantly with compile times and it seems this `TableContent` component already had a bunch of `'static` requirements so I figured why not.