### PR TITLE
Add refresh functionality

### DIFF
--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -41,7 +41,7 @@ pub trait TableDataProvider<Row, Err: Debug = String> {
     async fn get_rows(&self, range: Range<usize>) -> Result<(Vec<Row>, Range<usize>), Err>;
 
     /// Refresh data dependant side effects without reloading the data.
-    /// This method is called right after get_page.
+    /// This method is called right after get_rows.
     #[allow(unused_variables)]
     fn refresh(&self, rows: Vec<RwSignal<Row>>) {
         // By default, do nothing.

--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -4,6 +4,7 @@ use crate::ColumnSort;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::ops::Range;
+use leptos::prelude::RwSignal;
 
 /// The trait that provides data for the `<TableContent>` component.
 /// Anything that is passed to the `rows` prop must implement this trait.
@@ -38,6 +39,13 @@ pub trait TableDataProvider<Row, Err: Debug = String> {
     /// In the case of an error the returned error `String` is going to be displayed in a
     /// in place of the failed rows.
     async fn get_rows(&self, range: Range<usize>) -> Result<(Vec<Row>, Range<usize>), Err>;
+
+    /// Refresh data dependant side effects without reloading the data.
+    /// This method is called right after get_page.
+    #[allow(unused_variables)]
+    fn refresh(&self, rows: Vec<RwSignal<Row>>) {
+        // By default, do nothing.
+    }
 
     /// The total number of rows in the table. Returns `None` if unknown (which is the default).
     async fn row_count(&self) -> Option<usize> {
@@ -80,6 +88,13 @@ pub trait PaginatedTableDataProvider<Row, Err: Debug = String> {
     /// If you return less than `PAGE_ROW_COUNT` rows, it is assumed that the end of the
     /// data has been reached.
     async fn get_page(&self, page_index: usize) -> Result<Vec<Row>, Err>;
+
+    /// Refresh data dependant side effects without reloading the data.
+    /// This method is called right after get_page.
+    #[allow(unused_variables)]
+    fn refresh(&self, rows: Vec<RwSignal<Row>>) {
+        // By default, do nothing.
+    }
 
     /// The total number of rows in the table. Returns `None` if unknown (which is the default).
     ///
@@ -126,6 +141,10 @@ where
             let len = rows.len();
             (rows, start..start + len)
         })
+    }
+
+    fn refresh(&self, rows: Vec<RwSignal<Row>>) {
+        PaginatedTableDataProvider::<Row, Err>::refresh(self, rows)
     }
 
     async fn row_count(&self) -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,7 @@ mod display_strategy;
 mod events;
 mod loaded_rows;
 mod reload_controller;
+mod refresh_controller;
 mod row_reader;
 #[cfg(feature = "rust_decimal")]
 pub mod rust_decimal;
@@ -432,6 +433,7 @@ pub use events::*;
 pub use leptos_struct_table_macro::TableRow;
 pub use loaded_rows::RowState;
 pub use reload_controller::*;
+pub use refresh_controller::*;
 pub use row_reader::*;
 pub use selection::*;
 pub use sorting::*;

--- a/src/refresh_controller.rs
+++ b/src/refresh_controller.rs
@@ -1,0 +1,21 @@
+use leptos::prelude::*;
+
+/// You can pass this to a [`TableContent`] component's `refresh_controller` prop to trigger a refresh of calculated values.
+#[derive(Copy, Clone)]
+pub struct RefreshController(Trigger);
+
+impl Default for RefreshController {
+    fn default() -> Self {
+        Self(Trigger::default())
+    }
+}
+
+impl RefreshController {
+    pub fn refresh(&self) {
+        self.0.notify();
+    }
+
+    pub fn track(&self) {
+        self.0.track();
+    }
+}


### PR DESCRIPTION
Good day,

This PR aims to add a way to recalculate values based on rows, without reloading the table.

Ex.: I have a receipts table and would like to have the total. 
Using the ReceiptsDataProvider, I will pass the sum of my currently loaded rows as a calculated total to the context of my application.  This works with the current implementation of the table. But if I do update a row, I am forced to reload the table to have access to the new information, lose the currently selected row, etc.... 

With this implementation, we separate the loading of the data from the calculated values and can recall it as many times as needed without reloading data and keeping the selected row selected.

A nice unintended effect is that we gain access to the list of RwSignal that can be shared out of the table, while keeping the data in sync. This is not yet tested on my part, as it was not the intended use case. If this creates more problem then it solve, a signal would suffice to the intended use case of refresh. Otherwise, it would allow for side forms directly affecting the table and vice-versa.

I did not spend days studying the library, so if anything seems out of place, or could be improved, I am all hears. 