### PR TITLE
Fix rare panics: Replaces the table_body element reference with a safer type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ leptos-use = { version = "0.19", default-features = false, features = [
     "use_scroll",
 ] }
 rust_decimal = { version = "1", optional = true }
-send_wrapper = "0.6"
 serde = "1"
 time = { version = "0.3", optional = true, features = ["formatting"] }
 uuid = { version = "1", optional = true, features = [] }

--- a/src/components/table_content.rs
+++ b/src/components/table_content.rs
@@ -390,7 +390,7 @@ where
         .into()
     };
 
-    let tbody_el = RwSignal::new_local(None::<web_sys::Element>);
+    let tbody_el = RwSignal::new(None::<web_sys::Element>);
 
     let compute_average_row_height = use_debounce_fn(
         move || {
@@ -683,7 +683,7 @@ where
     };
 
     let tbody_directive = Arc::new(move |el: web_sys::Element, _: ()| {
-        tbody_el.set(Some(el));
+        tbody_el.update(|tbody_el_mut| *tbody_el_mut = Some(el));
     });
 
     let tbody = tbody_renderer.run(tbody_content, tbody_class, tbody_directive);
@@ -719,7 +719,7 @@ where
 }
 
 fn compute_average_row_height_from_loaded<Row, Column, ClsP>(
-    tbody_ref: RwSignal<Option<web_sys::Element>, LocalStorage>,
+    tbody_ref: RwSignal<Option<web_sys::Element>>,
     display_range: ReadSignal<Range<usize>>,
     y: Signal<f64>,
     set_y: &impl Fn(f64),


### PR DESCRIPTION
Fixes https://github.com/Synphonyte/leptos-struct-table/issues/93

Replaces the container-type of the table_body element with a ssr safe one.

_I'm not 100% sure of the consequences here. I learned most of these concepts today._

**More background for the curious:**
I had occasional panics when visiting pages with tables, I picked up https://godzie44.github.io/BugStalker/docs/capabilities/symbol and my lldb debugger today to find potential causes.

My lldb stacktrace eventually pointed me to this line
```
<send_wrapper::SendWrapper<reactive_graph::signal::arc_rw::ArcRwSignal<core::option::Option<web_sys::features::gen_Element::Element>>>>::new(data={defined_at:{filename:{pointer:{data_ptr:"/home/mverstraete/.cargo/git/checkouts/leptos-struct-table-9cc4de7b19fdb5c3/afc78e4/src/components/table_content.rs", length:115}}
```
I was quite surprised that RwSignal::new_local was creating a SendWrapper behind the scenes.

Leptos maintainer gbj thought me today that SendWrappers should not be created on the SSR side, instead they should be Option<SendWrapper>::None variants on the server. 

gbj also mentioned SendOption as safer version of SendWrapper.

But `impl Send` didn't seem required for this variable so I just dropped the SendWrapper stuff entirely. 

Discord convo: https://discord.com/channels/1031524867910148188/1031524868883218474/1544335352104226990
